### PR TITLE
chore: Prevent committing to main branch via lefthook

### DIFF
--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -1,0 +1,4 @@
+pre-commit:
+  commands:
+    no-commit-to-main:
+      run: '[ "$(git rev-parse --abbrev-ref HEAD)" != "main" ]'


### PR DESCRIPTION
I'm tired of accidentally committing to main locally, then having to
rejig branches when pushing to GitHub, so we introduce [lefthook][1] to
help with this.

[1]: https://evilmartians.github.io/lefthook/
